### PR TITLE
feat: OnConflict support mysql VALUES

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ db.CreateMany([]interface{}{&user1, &user2, &user3}, 'constraint_name', &User{Up
 db.CreateMany([]interface{}{&user1, &user1, &user1})
 ```
 
+> Caution: mssql db driver will not raise error on duplicate
+> **Caution: CreateMany will not trigger `afterCreateCallback`**
+
+### MySQL VALUES function
+
+```go
+// only support MySQL: ON DUPLICATE KEY UPDATE `field` = VALUES(`field`), ...
+DB.CreateMany([]interface{}{
+	&Email{Id: 1, UserId: 100, Email: "jeff@example.com"},
+	&Email{Id: 2, UserId: 100, Email: "alan@example.com"},
+}, "updated_at", "email")
+db.CreateOnConflict(User{UserName: "gorm"}, "updated_at")
+```
+
 ## License
 
 © Jinzhu, 2013~time.Now

--- a/callback_create.go
+++ b/callback_create.go
@@ -262,6 +262,9 @@ func forceReloadAfterCreateCallback(scope *Scope) {
 
 // afterCreateCallback will invoke `AfterCreate`, `AfterSave` method after creating
 func afterCreateCallback(scope *Scope) {
+	if _, ok := scope.Get("gorm:create_many"); ok {
+		return
+	}
 	if !scope.HasError() {
 		scope.CallMethod("AfterCreate")
 	}

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -245,7 +245,17 @@ func (mysql) DefaultValueStr() string {
 	return "VALUES()"
 }
 
-func (mysql) OnConflict(values ...interface{}) (string, string, interface{}) {
+func (d mysql) OnConflict(values ...interface{}) (string, string, interface{}) {
+	if len(values) > 1 {
+		// UPDATE `field` = VALUES(`field`), ...
+		updateKVs := []string{}
+		for _, fieldName := range values {
+			k := d.Quote(fieldName.(string))
+			v := fmt.Sprintf("VALUES(%s)", k)
+			updateKVs = append(updateKVs, fmt.Sprintf("%v = %v", k, v))
+		}
+		return "", fmt.Sprintf("ON DUPLICATE KEY UPDATE %v", strings.Join(updateKVs, ",")), nil
+	}
 	switch values[0].(type) {
 	case string:
 		return "IGNORE", "", nil


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?

#### support MySQL VALUES function at ON DUPLICATE KEY UPDATE

```go
// only support MySQL: ON DUPLICATE KEY UPDATE `field` = VALUES(`field`), ...
DB.CreateMany([]interface{}{
	&Email{Id: 1, UserId: 100, Email: "jeff@example.com"},
	&Email{Id: 2, UserId: 100, Email: "alan@example.com"},
}, "updated_at", "email")
```