### PR TITLE
fix: mysql update VALUES when only one value

### DIFF
--- a/create_test.go
+++ b/create_test.go
@@ -533,6 +533,18 @@ func TestCreateMany(t *testing.T) {
 		if !emailResult2.UpdatedAt.After(email2.UpdatedAt) {
 			t.Error("UpdatedAt should be updated")
 		}
+		// only UPDATE one field
+		DB.CreateMany([]interface{}{
+			&Email{Id: 1, UserId: 100, Email: "same@qq.com"},
+			&Email{Id: 2, UserId: 100, Email: "same@qq.com"},
+		}, "email")
+		emailResult1 = Email{}
+		emailResult2 = Email{}
+		DB.Model(&Email{}).Find(&emailResult1, 1)
+		DB.Model(&Email{}).Find(&emailResult2, 2)
+		if emailResult1.Email != "same@qq.com" || emailResult2.Email != "same@qq.com" {
+			t.Error("Email should be same@qq.com")
+		}
 	}
 
 	DB.Delete(&Email{})

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -246,18 +246,18 @@ func (mysql) DefaultValueStr() string {
 }
 
 func (d mysql) OnConflict(values ...interface{}) (string, string, interface{}) {
-	if len(values) > 1 {
-		// UPDATE `field` = VALUES(`field`), ...
-		updateKVs := []string{}
-		for _, fieldName := range values {
-			k := d.Quote(fieldName.(string))
-			v := fmt.Sprintf("VALUES(%s)", k)
-			updateKVs = append(updateKVs, fmt.Sprintf("%v = %v", k, v))
-		}
-		return "", fmt.Sprintf("ON DUPLICATE KEY UPDATE %v", strings.Join(updateKVs, ",")), nil
-	}
 	switch values[0].(type) {
 	case string:
+		if len(values) > 1 || values[0].(string) != IGNORE {
+			// UPDATE `field` = VALUES(`field`), ...
+			updateKVs := []string{}
+			for _, fieldName := range values {
+				k := d.Quote(fieldName.(string))
+				v := fmt.Sprintf("VALUES(%s)", k)
+				updateKVs = append(updateKVs, fmt.Sprintf("%v = %v", k, v))
+			}
+			return "", fmt.Sprintf("ON DUPLICATE KEY UPDATE %v", strings.Join(updateKVs, ",")), nil
+		}
 		return "IGNORE", "", nil
 	default:
 		return "", "ON DUPLICATE KEY UPDATE %v", values[0]


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?

Fix `VALUES` at MySQL's `ON DUPLICATE KEY UPDATE` when only one param.